### PR TITLE
Removed setResponseData from Publisher

### DIFF
--- a/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
+++ b/src/main/com/zeroclue/jmeter/protocol/amqp/AMQPPublisher.java
@@ -105,7 +105,6 @@ public class AMQPPublisher extends AMQPSampler implements Interruptible {
              * Set up the sample result details
              */
             result.setSamplerData(data);
-            result.setResponseData(new String(messageBytes), null);
             result.setDataType(SampleResult.TEXT);
 
             result.setResponseCodeOK();


### PR DESCRIPTION
JMeter's setResponseData method is intended to accept responses from whatever JMeter's sampler was returned from what it connected to. However, setResponseData is just putting in the message that was delivered to a message queue; basicPublish does not return anything.